### PR TITLE
feat(ux): chat HUD + persistence; feat(lab): A/B prompt testing with export

### DIFF
--- a/web/e2e/lab.spec.ts
+++ b/web/e2e/lab.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+test("lab prompt A/B testing flow", async ({ page }) => {
+  await page.goto("/lab");
+
+  await expect(page.getByText("Prompt Lab")).toBeVisible();
+
+  const systemPromptA = page.getByPlaceholder("Describe system prompt A here...");
+  await systemPromptA.fill("You are assistant alpha. Always include the word 'alpha' in your responses.");
+
+  const systemPromptB = page.getByPlaceholder("Describe system prompt B here...");
+  await systemPromptB.fill("You are assistant beta. Always include the word 'beta' in your responses.");
+
+  const userInput = page.getByPlaceholder("User message to test with both prompts...");
+  await userInput.fill("Hello, how are you today?");
+
+  await page.getByRole("button", { name: "Run Both" }).click();
+
+  await expect(page.getByText("alpha")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText("beta")).toBeVisible({ timeout: 10_000 });
+
+  await expect(page.getByRole("button", { name: "Export JSONL" })).toBeEnabled({ timeout: 5_000 });
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole("button", { name: "Export JSONL" }).click();
+  
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(/\.jsonl$/);
+});

--- a/web/src/app/(lab)/lab/__tests__/lab.test.tsx
+++ b/web/src/app/(lab)/lab/__tests__/lab.test.tsx
@@ -1,0 +1,209 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import LabPage from "../page";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const encoder = new TextEncoder();
+
+function createMockStreamResponse(chunks: string[]) {
+  const stream = new ReadableStream({
+    start(controller) {
+      chunks.forEach(chunk => {
+        controller.enqueue(encoder.encode(chunk));
+      });
+      controller.close();
+    }
+  });
+
+  const response = new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/plain" }
+  });
+  Object.defineProperty(response, 'ok', { value: true });
+  return Promise.resolve(response);
+}
+
+describe("LabPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the lab page component", () => {
+    render(<LabPage />);
+    
+    expect(screen.getByText("Prompt Lab")).toBeInTheDocument();
+    expect(screen.getByLabelText(/System Prompt A/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/System Prompt B/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/User Input/i)).toBeInTheDocument();
+    expect(screen.getByText("Run A")).toBeInTheDocument();
+    expect(screen.getByText("Run B")).toBeInTheDocument();
+    expect(screen.getByText("Run Both")).toBeInTheDocument();
+  });
+
+  it("disables run buttons when user input is empty", () => {
+    render(<LabPage />);
+    
+    expect(screen.getByRole("button", { name: "Run A" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Run B" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Run Both" })).toBeDisabled();
+  });
+
+  it("enables run buttons when user input is provided", () => {
+    render(<LabPage />);
+    
+    const userInput = screen.getByLabelText(/User Input/i);
+    fireEvent.change(userInput, { target: { value: "Test message" } });
+    
+    expect(screen.getByRole("button", { name: "Run A" })).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "Run B" })).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "Run Both" })).not.toBeDisabled();
+  });
+
+  it("populates both columns when Run Both is clicked", async () => {
+    // Mock streaming responses for both runs
+    mockFetch
+      .mockImplementationOnce(() => createMockStreamResponse(["Response ", "A"]))
+      .mockImplementationOnce(() => createMockStreamResponse(["Response ", "B"]));
+
+    render(<LabPage />);
+    
+    // Fill in the form
+    const systemPromptA = screen.getByLabelText(/System Prompt A/i);
+    const systemPromptB = screen.getByLabelText(/System Prompt B/i);
+    const userInput = screen.getByLabelText(/User Input/i);
+    
+    fireEvent.change(systemPromptA, { target: { value: "You are assistant A" } });
+    fireEvent.change(systemPromptB, { target: { value: "You are assistant B" } });
+    fireEvent.change(userInput, { target: { value: "Hello there" } });
+    
+    // Click Run Both
+    const runBothButton = screen.getByRole("button", { name: "Run Both" });
+    fireEvent.click(runBothButton);
+
+    // Verify both fetch calls were made
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    
+    // Verify the requests have the correct payloads
+    expect(mockFetch).toHaveBeenNthCalledWith(1, "/api/chat/stream", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [
+          { role: "system", content: "You are assistant A" },
+          { role: "user", content: "Hello there" }
+        ]
+      }),
+      signal: expect.any(AbortSignal)
+    });
+    
+    expect(mockFetch).toHaveBeenNthCalledWith(2, "/api/chat/stream", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [
+          { role: "system", content: "You are assistant B" },
+          { role: "user", content: "Hello there" }
+        ]
+      }),
+      signal: expect.any(AbortSignal)
+    });
+
+    // Wait for the responses to populate
+    await waitFor(() => {
+      expect(screen.getByText("Response A")).toBeInTheDocument();
+    }, { timeout: 3000 });
+    
+    await waitFor(() => {
+      expect(screen.getByText("Response B")).toBeInTheDocument();
+    }, { timeout: 3000 });
+  });
+
+  it("records latencies for both runs", async () => {
+    mockFetch
+      .mockImplementationOnce(() => createMockStreamResponse(["A"]))
+      .mockImplementationOnce(() => createMockStreamResponse(["B"]));
+
+    render(<LabPage />);
+    
+    // Fill in required fields
+    fireEvent.change(screen.getByLabelText(/User Input/i), { 
+      target: { value: "Test" } 
+    });
+    
+    // Click Run Both
+    fireEvent.click(screen.getByRole("button", { name: "Run Both" }));
+
+    // Wait for completion and check that some latency is displayed (with space)
+    await waitFor(() => {
+      const latencyElements = screen.getAllByText(/\d+ ms/);
+      expect(latencyElements.length).toBeGreaterThan(0);
+    }, { timeout: 3000 });
+  });
+
+  it("clears outputs when Clear is clicked", async () => {
+    mockFetch.mockImplementation(() => createMockStreamResponse(["Test output"]));
+
+    render(<LabPage />);
+    
+    // Fill and run
+    fireEvent.change(screen.getByLabelText(/User Input/i), { 
+      target: { value: "Test" } 
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Run A" }));
+
+    // Wait for output
+    await waitFor(() => {
+      expect(screen.getByText("Test output")).toBeInTheDocument();
+    }, { timeout: 3000 });
+
+    // Clear outputs
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+
+    // Verify output is cleared
+    expect(screen.queryByText("Test output")).not.toBeInTheDocument();
+  });
+
+  it("handles fetch errors gracefully", async () => {
+    mockFetch.mockRejectedValue(new Error("Network error"));
+
+    render(<LabPage />);
+    
+    fireEvent.change(screen.getByLabelText(/User Input/i), { 
+      target: { value: "Test" } 
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Run A" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/\[error\] Network error/)).toBeInTheDocument();
+    });
+  });
+
+  it("can export results to JSONL when records exist", async () => {
+    mockFetch.mockImplementation(() => createMockStreamResponse(["Test response"]));
+
+    render(<LabPage />);
+    
+    // Export should be disabled initially
+    expect(screen.getByRole("button", { name: "Export JSONL" })).toBeDisabled();
+    
+    // Run a test to generate records
+    fireEvent.change(screen.getByLabelText(/User Input/i), { 
+      target: { value: "Test export" } 
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Run A" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Export JSONL" })).not.toBeDisabled();
+    }, { timeout: 3000 });
+
+    expect(screen.getByRole("button", { name: "Export JSONL" })).not.toBeDisabled();
+  });
+});

--- a/web/src/app/(lab)/lab/page.tsx
+++ b/web/src/app/(lab)/lab/page.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import React, { useCallback, useRef, useState } from "react";
+import type { ButtonHTMLAttributes } from "react";
+
+type LabRunRecord = {
+  label: "A" | "B";
+  systemPrompt: string;
+  userPrompt: string;
+  output: string;
+  latencyMs: number | null;
+  timestamp: string;
+};
+
+interface LabRunnerState {
+  output: string;
+  isStreaming: boolean;
+  latencyMs: number | null;
+  run: (systemPrompt: string, userPrompt: string) => Promise<void>;
+  clear: () => void;
+}
+
+const decoder = new TextDecoder();
+
+function useLabRunner(label: "A" | "B", onFinish: (record: LabRunRecord) => void): LabRunnerState {
+  const [output, setOutput] = useState("");
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const clear = useCallback(() => {
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    setOutput("");
+    setIsStreaming(false);
+    setLatencyMs(null);
+  }, []);
+
+  const run = useCallback(
+    async (systemPrompt: string, userPrompt: string) => {
+      if (!systemPrompt.trim() || !userPrompt.trim()) {
+        return;
+      }
+
+      abortControllerRef.current?.abort();
+
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      setOutput("");
+      setIsStreaming(true);
+      setLatencyMs(null);
+
+      const start = performance.now();
+      let aggregated = "";
+      const messages = [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ];
+
+      try {
+        const response = await fetch("/api/chat/stream", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ messages }),
+          signal: controller.signal,
+        });
+
+        if (!response.ok || !response.body) {
+          const errorText = await response.text();
+          throw new Error(errorText || `Run ${label} failed with status ${response.status}`);
+        }
+
+        const reader = response.body.getReader();
+        let done = false;
+
+        while (!done) {
+          const { value, done: readerDone } = await reader.read();
+          done = readerDone;
+
+          if (value) {
+            const textChunk = decoder.decode(value, { stream: !readerDone });
+            if (textChunk) {
+              aggregated += textChunk;
+              setOutput(aggregated);
+            }
+          }
+        }
+
+        setOutput(aggregated);
+
+        const elapsed = performance.now() - start;
+        setLatencyMs(elapsed);
+        const record: LabRunRecord = {
+          label,
+          systemPrompt,
+          userPrompt,
+          output: aggregated,
+          latencyMs: elapsed,
+          timestamp: new Date().toISOString(),
+        };
+        onFinish(record);
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          // ignore
+        } else {
+          const message = error instanceof Error ? error.message : String(error);
+          setOutput((prev) => (prev ? `${prev}\n[error] ${message}` : `[error] ${message}`));
+        }
+      } finally {
+        setIsStreaming(false);
+        abortControllerRef.current = null;
+      }
+    },
+    [label, onFinish],
+  );
+
+  return {
+    output,
+    isStreaming,
+    latencyMs,
+    run,
+    clear,
+  };
+}
+
+export default function LabPage() {
+  const [systemPromptA, setSystemPromptA] = useState("You are prompt A.");
+  const [systemPromptB, setSystemPromptB] = useState("You are prompt B.");
+  const [userPrompt, setUserPrompt] = useState("");
+  const [records, setRecords] = useState<LabRunRecord[]>([]);
+
+  const pushRecord = useCallback((record: LabRunRecord) => {
+    setRecords((prev) => [...prev, record]);
+  }, []);
+
+  const runnerA = useLabRunner("A", pushRecord);
+  const runnerB = useLabRunner("B", pushRecord);
+
+  const runA = useCallback(() => {
+    void runnerA.run(systemPromptA, userPrompt);
+  }, [runnerA, systemPromptA, userPrompt]);
+
+  const runB = useCallback(() => {
+    void runnerB.run(systemPromptB, userPrompt);
+  }, [runnerB, systemPromptB, userPrompt]);
+
+  const runBoth = useCallback(() => {
+    runA();
+    runB();
+  }, [runA, runB]);
+
+  const clearAll = useCallback(() => {
+    runnerA.clear();
+    runnerB.clear();
+    setUserPrompt("");
+    setRecords([]);
+  }, [runnerA, runnerB]);
+
+  const exportJsonl = useCallback(() => {
+    if (records.length === 0) return;
+    const lines = records.map((record) =>
+      JSON.stringify({
+        promptLabel: record.label,
+        systemPrompt: record.systemPrompt,
+        user: record.userPrompt,
+        output: record.output,
+        latencyMs: record.latencyMs,
+        timestamp: record.timestamp,
+      }),
+    );
+    const blob = new Blob([lines.join("\n")], { type: "application/jsonl" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `lab-runs-${Date.now()}.jsonl`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }, [records]);
+
+  const charCountA = runnerA.output.length;
+  const charCountB = runnerB.output.length;
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10">
+      <header className="space-y-3">
+        <h1 className="text-3xl font-semibold text-zinc-900 dark:text-zinc-100">Prompt Lab</h1>
+        <p className="text-sm text-zinc-500 dark:text-zinc-400">
+          Compare two system prompts against the same user input. Runs hit the same streaming endpoint as the main chat.
+        </p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">System Prompt A</span>
+          <textarea
+            value={systemPromptA}
+            onChange={(event) => setSystemPromptA(event.target.value)}
+            rows={6}
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+            placeholder="Describe system prompt A here..."
+          />
+        </label>
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">System Prompt B</span>
+          <textarea
+            value={systemPromptB}
+            onChange={(event) => setSystemPromptB(event.target.value)}
+            rows={6}
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+            placeholder="Describe system prompt B here..."
+          />
+        </label>
+      </section>
+
+      <section className="space-y-3">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">User Input</span>
+          <textarea
+            value={userPrompt}
+            onChange={(event) => setUserPrompt(event.target.value)}
+            rows={4}
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+            placeholder="User message to test with both prompts..."
+          />
+        </label>
+
+        <div className="flex flex-wrap gap-3">
+          <Button disabled={!userPrompt.trim()} onClick={runA}>
+            Run A
+          </Button>
+          <Button disabled={!userPrompt.trim()} onClick={runB}>
+            Run B
+          </Button>
+          <Button disabled={!userPrompt.trim()} onClick={runBoth}>
+            Run Both
+          </Button>
+          <Button variant="outline" onClick={clearAll}>
+            Clear
+          </Button>
+          <Button variant="ghost" onClick={exportJsonl} disabled={records.length === 0}>
+            Export JSONL
+          </Button>
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <ResultCard
+          label="A"
+          output={runnerA.output}
+          isStreaming={runnerA.isStreaming}
+          latencyMs={runnerA.latencyMs}
+          charCount={charCountA}
+        />
+        <ResultCard
+          label="B"
+          output={runnerB.output}
+          isStreaming={runnerB.isStreaming}
+          latencyMs={runnerB.latencyMs}
+          charCount={charCountB}
+        />
+      </section>
+    </main>
+  );
+}
+
+interface ResultCardProps {
+  label: "A" | "B";
+  output: string;
+  isStreaming: boolean;
+  latencyMs: number | null;
+  charCount: number;
+}
+
+function ResultCard({ label, output, isStreaming, latencyMs, charCount }: ResultCardProps) {
+  return (
+    <article className="flex h-full flex-col gap-3 rounded-lg border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+      <header className="flex items-center justify-between">
+        <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Prompt {label}</span>
+        <span className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+          {isStreaming ? "Streaming…" : "Idle"}
+        </span>
+      </header>
+      <dl className="flex items-center gap-4 text-xs text-zinc-500 dark:text-zinc-400">
+        <div className="flex items-center gap-1">
+          <dt className="font-semibold text-zinc-700 dark:text-zinc-300">Latency:</dt>
+          <dd>{latencyMs != null ? `${Math.round(latencyMs)} ms` : "—"}</dd>
+        </div>
+        <div className="flex items-center gap-1">
+          <dt className="font-semibold text-zinc-700 dark:text-zinc-300">Chars:</dt>
+          <dd>{charCount}</dd>
+        </div>
+      </dl>
+      <div className="min-h-[160px] flex-1 rounded-md border border-zinc-200 bg-white/70 p-3 text-sm text-zinc-700 dark:border-zinc-800 dark:bg-zinc-950/60 dark:text-zinc-200">
+        {output ? output : <span className="text-zinc-400 dark:text-zinc-500">Awaiting output…</span>}
+        {isStreaming ? <span className="ml-1 inline-block animate-pulse">▌</span> : null}
+      </div>
+    </article>
+  );
+}
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "default" | "outline" | "ghost";
+}
+
+function Button({ variant = "default", className = "", type = "button", ...props }: ButtonProps) {
+  const base =
+    "inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-900 disabled:cursor-not-allowed disabled:opacity-60";
+  const variants: Record<string, string> = {
+    default:
+      "border-transparent bg-zinc-900 text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200",
+    outline:
+      "border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800",
+    ghost:
+      "border-transparent text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800",
+  };
+  return <button type={type} className={`${base} ${variants[variant]} ${className}`} {...props} />;
+}

--- a/web/src/app/api/chat/config/route.ts
+++ b/web/src/app/api/chat/config/route.ts
@@ -1,13 +1,20 @@
-'use server';
-
 import { getServerEnv, isMock } from "@/lib/env";
 
 export async function GET() {
-  const env = getServerEnv();
-
-  return Response.json({
-    model: env.MISTRAL_MODEL,
-    temperature: env.TEMPERATURE_DEFAULT,
-    mock: isMock(),
-  });
+  try {
+    const env = getServerEnv();
+    const mode = isMock() ? "mock" : "real";
+    
+    return Response.json({
+      model: env.MISTRAL_MODEL,
+      mode,
+    });
+  } catch (error) {
+    console.error("Failed to get chat config:", error);
+    
+    return Response.json(
+      { error: "Failed to get chat configuration" },
+      { status: 500 }
+    );
+  }
 }

--- a/web/src/components/app-shell/Nav.tsx
+++ b/web/src/components/app-shell/Nav.tsx
@@ -8,6 +8,7 @@ const linkClass =
 const links = [
   { href: "/", label: "Home" },
   { href: "/chat", label: "Chat" },
+  { href: "/lab", label: "Lab" },
 ];
 
 export default function Nav() {

--- a/web/src/lib/__tests__/persist.test.ts
+++ b/web/src/lib/__tests__/persist.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { saveMessages, loadMessages, clearMessages, KEY } from "../persist";
+import type { ChatMessage } from "../types";
+
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+};
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});
+
+describe("persist", () => {
+  const mockMessages: ChatMessage[] = [
+    {
+      id: "1",
+      role: "user",
+      content: "Hello",
+      createdAt: 1234567890,
+    },
+    {
+      id: "2",
+      role: "assistant",
+      content: "Hi there!",
+      createdAt: 1234567891,
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("saveMessages", () => {
+    it("should save messages to localStorage", () => {
+      saveMessages(mockMessages);
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        KEY,
+        JSON.stringify(mockMessages)
+      );
+    });
+
+    it("should handle JSON.stringify errors gracefully", () => {
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const circularMessage = { id: "1", role: "user", content: "test", createdAt: 123 } as any;
+      circularMessage.circular = circularMessage; // Create circular reference
+
+      saveMessages([circularMessage]);
+
+      expect(consoleSpy).toHaveBeenCalledWith("Failed to save chat messages", expect.any(Error));
+      consoleSpy.mockRestore();
+    });
+
+    it("should handle localStorage.setItem errors gracefully", () => {
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      localStorageMock.setItem.mockImplementation(() => {
+        throw new Error("Storage full");
+      });
+
+      saveMessages(mockMessages);
+
+      expect(consoleSpy).toHaveBeenCalledWith("Failed to save chat messages", expect.any(Error));
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("loadMessages", () => {
+    it("should load valid messages from localStorage", () => {
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(mockMessages));
+
+      const result = loadMessages();
+
+      expect(localStorageMock.getItem).toHaveBeenCalledWith(KEY);
+      expect(result).toEqual(mockMessages);
+    });
+
+    it("should return null when localStorage returns null", () => {
+      localStorageMock.getItem.mockReturnValue(null);
+
+      const result = loadMessages();
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when localStorage returns empty string", () => {
+      localStorageMock.getItem.mockReturnValue("");
+
+      const result = loadMessages();
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null for invalid JSON", () => {
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      localStorageMock.getItem.mockReturnValue("invalid json");
+
+      const result = loadMessages();
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith("Failed to load chat messages", expect.any(Error));
+      consoleSpy.mockRestore();
+    });
+
+    it("should return null when data is not an array", () => {
+      localStorageMock.getItem.mockReturnValue(JSON.stringify({ not: "array" }));
+
+      const result = loadMessages();
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when array contains invalid messages", () => {
+      const invalidMessages = [
+        { id: "1", role: "user", content: "Hello", createdAt: 123 },
+        { id: 2, role: "assistant", content: "Hi", createdAt: 124 }, // invalid id type
+      ];
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(invalidMessages));
+
+      const result = loadMessages();
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when message has invalid role", () => {
+      const invalidMessages = [
+        { id: "1", role: "invalid", content: "Hello", createdAt: 123 },
+      ];
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(invalidMessages));
+
+      const result = loadMessages();
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle localStorage.getItem errors gracefully", () => {
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      localStorageMock.getItem.mockImplementation(() => {
+        throw new Error("Storage error");
+      });
+
+      const result = loadMessages();
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith("Failed to load chat messages", expect.any(Error));
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("clearMessages", () => {
+    it("should remove messages from localStorage", () => {
+      clearMessages();
+
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith(KEY);
+    });
+
+    it("should handle localStorage.removeItem errors gracefully", () => {
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      localStorageMock.removeItem.mockImplementation(() => {
+        throw new Error("Storage error");
+      });
+
+      clearMessages();
+
+      expect(consoleSpy).toHaveBeenCalledWith("Failed to clear chat messages", expect.any(Error));
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/web/src/lib/persist.ts
+++ b/web/src/lib/persist.ts
@@ -1,0 +1,49 @@
+import type { ChatMessage } from "./types";
+
+export const KEY = "lechatpp.messages.v1";
+
+export function saveMessages(messages: ChatMessage[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    const payload = JSON.stringify(messages);
+    window.localStorage.setItem(KEY, payload);
+  } catch (error) {
+    console.warn("Failed to save chat messages", error);
+  }
+}
+
+export function loadMessages(): ChatMessage[] | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    if (
+      parsed.every(
+        (item) =>
+          item &&
+          typeof item === "object" &&
+          typeof item.id === "string" &&
+          (item.role === "user" || item.role === "assistant" || item.role === "system") &&
+          typeof item.content === "string" &&
+          typeof item.createdAt === "number",
+      )
+    ) {
+      return parsed as ChatMessage[];
+    }
+    return null;
+  } catch (error) {
+    console.warn("Failed to load chat messages", error);
+    return null;
+  }
+}
+
+export function clearMessages(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(KEY);
+  } catch (error) {
+    console.warn("Failed to clear chat messages", error);
+  }
+}


### PR DESCRIPTION
## Summary
Polish chat UX (streaming cursor, HUD with model/mode/latency) and persist messages locally. Add a new **Prompt Lab** to A/B test system prompts with side-by-side streaming and JSONL export.

## Changes
- Chat HUD (model, mode badge, latency, token placeholder) and streaming cursor.
- LocalStorage-backed message persistence (versioned).
- New `/lab` route with A/B runs (Run A, Run B, Run Both), metrics, and Export JSONL.
- Optional `/api/chat/config` to surface model/mode to the client.
- Unit tests for persistence and lab flows; Playwright e2e for lab page.

## How to Verify
- `make dev` → `/chat`: send a message; refresh → messages remain; HUD shows mode.
- `/lab`: enter prompts and a query; Run Both → both columns stream; Export JSONL triggers a download.
- Tests: `pnpm --dir web test --run` and `pnpm --dir web playwright test`.

## Notes
- Works in mock and real mode. CI remains in mock.