### PR TITLE
feat(docker): complete Docker setup with dev mode, env validation, and datasets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Dependencies
+node_modules
+*/node_modules
+
+# Development files
+.next
+.vscode
+.idea
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Git
+.git
+
+# Logs
+*.log
+
+# Docker
+Dockerfile*
+docker-compose*

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to .env and configure your settings
+
+# Set to 'false' to use real Mistral API, 'true' for mock responses
+USE_MOCK=true
+
+# Required if USE_MOCK=false
+MISTRAL_API_KEY=your_mistral_api_key_here
+
+# Mistral model to use
+MISTRAL_MODEL=mistral-small-latest
+
+# Default temperature for responses
+TEMPERATURE_DEFAULT=0.2

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev lint typecheck test test\:e2e test\:e2e\:ci build start
+.PHONY: setup dev lint typecheck test test\:e2e test\:e2e\:ci build start docker\:build docker\:up docker\:down docker\:dev
 
 setup:
 	cd web && pnpm install
@@ -26,3 +26,12 @@ build:
 
 start:
 	cd web && pnpm start
+
+docker\:build:
+	docker compose build
+
+docker\:up:
+	docker compose up -d
+
+docker\:down:
+	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
-version: "3.9"
-
 services:
   web:
     build:
       context: .
       dockerfile: docker/Dockerfile.web
+      target: base
     ports:
       - "3000:3000"
-    volumes:
-      - ./web:/app
-    command: pnpm dev
-    # Enable if file watching requires polling (e.g., some macOS setups)
-    # environment:
-    #   CHOKIDAR_USEPOLLING: "1"
+    environment:
+      - USE_MOCK=${USE_MOCK:-true}
+      - MISTRAL_API_KEY=${MISTRAL_API_KEY}
+      - MISTRAL_MODEL=${MISTRAL_MODEL:-mistral-small-latest}
+      - TEMPERATURE_DEFAULT=${TEMPERATURE_DEFAULT:-0.2}
+    command: ["pnpm", "dev"]
+    restart: unless-stopped

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,19 +1,48 @@
+# Multi-stage build for production
 FROM node:22-slim AS base
 
+# Install curl for health checks
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+# Install pnpm
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
 WORKDIR /app
 
-COPY web/pnpm-lock.yaml web/package.json ./
+# Copy workspace package files
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY web/package.json ./web/
 
+# Install dependencies for the workspace
 RUN pnpm install --frozen-lockfile
 
-COPY web .
+# Copy web source code
+COPY web ./web
 
-RUN pnpm build
+# Copy datasets directory
+COPY datasets ./datasets
 
+# Set working directory to web
+WORKDIR /app/web
+
+# Production build stage
+FROM base AS production
+
+# Set environment variable to disable problematic Next.js features during build
+ENV NEXT_TELEMETRY_DISABLED 1
+ENV NODE_ENV production
+
+# Build the application
+RUN pnpm run build
+
+# Expose port
 EXPOSE 3000
 
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:3000/api/chat/config || exit 1
+
+# Start the application
 CMD ["pnpm", "start"]

--- a/web/src/lib/env.ts
+++ b/web/src/lib/env.ts
@@ -24,10 +24,10 @@ export const envSchema = z
       .refine((value) => value >= 0 && value <= 2, {
         message: "TEMPERATURE_DEFAULT must be between 0 and 2",
       }),
-    MISTRAL_API_KEY: z.string().min(1).optional(),
+    MISTRAL_API_KEY: z.string().optional(),
   })
   .superRefine((data, ctx) => {
-    if (!data.USE_MOCK && !data.MISTRAL_API_KEY) {
+    if (!data.USE_MOCK && (!data.MISTRAL_API_KEY || data.MISTRAL_API_KEY.length === 0)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "MISTRAL_API_KEY is required when USE_MOCK is false",


### PR DESCRIPTION
## Summary
Complete Docker setup for easy testing with both mock and real API modes.

## Changes
- Docker infrastructure: Multi-stage Dockerfile with development target 
- Simplified setup: Clean docker-compose.yml with single service, removed confusing override files
- Make commands: Streamlined docker:build, docker:up, docker:down targets- 

## How to Verify
- Mock mode: make docker:build && make docker:up → http://localhost:3000 → chat works with mock responses
- Real mode: Add API key to .env, restart → real Mistral AI responses
- Eval dashboard: Visit /eval → datasets load, evaluations run with metrics
- All features: Navigate /, /chat, /eval, /lab → all pages functional

## Notes
- Works out-of-the-box with mock data (no API key required)
- Easy switch to real API via environment variables